### PR TITLE
Fix toast removal delay

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,7 +6,9 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Remove dismissed toasts from the DOM after a short delay.
+// The previous value left dismissed toasts hanging around for over 16 minutes.
+const TOAST_REMOVE_DELAY = 1000
 
 type ToasterToast = ToastProps & {
   id: string

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,8 +6,6 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-// Remove dismissed toasts from the DOM after a short delay.
-// The previous value left dismissed toasts hanging around for over 16 minutes.
 const TOAST_REMOVE_DELAY = 1000
 
 type ToasterToast = ToastProps & {


### PR DESCRIPTION
## Summary
- fix `use-toast.ts` so dismissed toasts are removed after 1s rather than 16 minutes

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6850dda3677883269842ccab76eec339