### PR TITLE
Memoize user profile fetch helpers

### DIFF
--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,5 +1,5 @@
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { User as SupabaseUser } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { User, ExpertiseType } from '@/types';
@@ -7,7 +7,7 @@ import { User, ExpertiseType } from '@/types';
 export const useUserProfile = () => {
   const [user, setUser] = useState<User | null>(null);
 
-  const fetchUserProfile = async (supabaseUser: SupabaseUser) => {
+  const fetchUserProfile = useCallback(async (supabaseUser: SupabaseUser) => {
     try {
       console.log('Fetching profile for user:', supabaseUser.id);
       
@@ -44,11 +44,11 @@ export const useUserProfile = () => {
     } catch (error) {
       console.error('Error in fetchUserProfile:', error);
     }
-  };
+  }, [setUser]);
 
-  const clearUser = () => {
+  const clearUser = useCallback(() => {
     setUser(null);
-  };
+  }, [setUser]);
 
   return {
     user,


### PR DESCRIPTION
## Summary
- optimize useUserProfile by memoizing fetch and clear helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685367d54b248326886a351631aae6dd