### PR TITLE
Fix duplicate hero subtitle text

### DIFF
--- a/src/components/WelcomeHero.tsx
+++ b/src/components/WelcomeHero.tsx
@@ -26,7 +26,7 @@ const WelcomeHero = () => {
             {t('welcomeTitle', 'Connecting Syrian Voices Worldwide')}
           </h1>
           <p className="text-xl md:text-2xl mb-4 text-white/90 max-w-3xl mx-auto">
-            {t('welcomeSubtitle', 'Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria')}
+            {t('welcomeSubtitle')}
           </p>
           <p className="text-lg mb-8 text-yellow-200 font-medium">
             {t('platformTagline', 'Where Syrian Expertise Meets Global Community')}

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -79,7 +79,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ onNavigateToMainPage }) => {
               </h1>
               
               <p className={`text-xl md:text-2xl mb-4 text-background/90 max-w-4xl mx-auto lg:${isRTL ? 'ml-0 mr-0' : 'mx-0'} leading-relaxed animate-slide-in-right`}>
-                {t('Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria\'s present and future')}
+                {t('welcomeSubtitle')}
               </p>
               
               <p className="text-lg mb-8 text-warning font-medium flex items-center justify-center animate-fade-in delay-300">

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -218,7 +218,6 @@ const resources = {
       'Connecting Syrian Voices Worldwide': 'Connecting Syrian Voices Worldwide',
       'Your Gateway to': 'Your Gateway to',
       'Syrian Knowledge': 'Syrian Knowledge',
-      'Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria\'s present and future': 'Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria\'s present and future',
       'Ask a Question': 'Ask a Question',
       'Join as Expert': 'Join as Expert',
       
@@ -504,7 +503,6 @@ const resources = {
       'Connecting Syrian Voices Worldwide': 'ربط الأصوات السورية عالمياً',
       'Your Gateway to': 'بوابتك إلى',
       'Syrian Knowledge': 'المعرفة السورية',
-      'Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria\'s present and future': 'تواصل مع الخبراء السوريين، اطرح الأسئلة، شارك الأخبار، وشارك في نقاشات مهمة حول حاضر ومستقبل سوريا',
       'Ask a Question': 'اطرح سؤالاً',
       'Join as Expert': 'انضم كخبير',
       


### PR DESCRIPTION
## Summary
- remove unused hero translation strings
- reuse `welcomeSubtitle` in `HeroSection`
- simplify `WelcomeHero` subtitle

## Testing
- `bun run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854b055609883269a136c7577c6e42e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated subtitle text in the hero section to use translation keys instead of hardcoded English strings, ensuring proper localization.
- **Chores**
  - Removed unused translation entries from the language resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->