### PR TITLE
Fix duplicate hero subtitle text

### DIFF
--- a/src/components/WelcomeHero.tsx
+++ b/src/components/WelcomeHero.tsx
@@ -23,13 +23,13 @@ const WelcomeHero = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 relative z-10">
         <div className="text-center">
           <h1 className="text-4xl md:text-6xl font-bold mb-6 animate-fade-in">
-            {t('welcomeTitle', 'Connecting Syrian Voices Worldwide')}
+            {t('welcomeTitle')}
           </h1>
           <p className="text-xl md:text-2xl mb-4 text-white/90 max-w-3xl mx-auto">
-            {t('welcomeSubtitle', 'Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria')}
+            {t('welcomeSubtitle')}
           </p>
           <p className="text-lg mb-8 text-yellow-200 font-medium">
-            {t('platformTagline', 'Where Syrian Expertise Meets Global Community')}
+            {t('platformTagline')}
           </p>
           
           {!user && (

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -67,7 +67,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ onNavigateToMainPage }) => {
             <div className={`text-center lg:${isRTL ? 'text-right' : 'text-left'} animate-fade-in`}>
               <Badge className="mb-6 bg-warning/20 text-warning border-warning/40 hover:bg-warning/30 transition-all duration-300 animate-bounce">
                 <Globe className={`w-4 h-4 ${isRTL ? 'ml-2' : 'mr-2'}`} />
-                {t('Connecting Syrian Voices Worldwide')}
+                {t('welcomeTitle')}
               </Badge>
               
               <h1 className="text-4xl md:text-6xl font-bold mb-6 animate-fade-in leading-tight">
@@ -79,7 +79,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ onNavigateToMainPage }) => {
               </h1>
               
               <p className={`text-xl md:text-2xl mb-4 text-background/90 max-w-4xl mx-auto lg:${isRTL ? 'ml-0 mr-0' : 'mx-0'} leading-relaxed animate-slide-in-right`}>
-                {t('Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria\'s present and future')}
+                {t('welcomeSubtitle')}
               </p>
               
               <p className="text-lg mb-8 text-warning font-medium flex items-center justify-center animate-fade-in delay-300">

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -215,12 +215,6 @@ const resources = {
       'Expert Members': 'Expert Members',
       
       // Landing Page - Hero Section
-      'Connecting Syrian Voices Worldwide': 'Connecting Syrian Voices Worldwide',
-      'Your Gateway to': 'Your Gateway to',
-      'Syrian Knowledge': 'Syrian Knowledge',
-      'Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria\'s present and future': 'Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria\'s present and future',
-      'Ask a Question': 'Ask a Question',
-      'Join as Expert': 'Join as Expert',
       
       // Profile Updates
       profileUpdated: 'Profile Updated',
@@ -501,12 +495,6 @@ const resources = {
       'Expert Members': 'الأعضاء الخبراء',
       
       // Landing Page - Hero Section
-      'Connecting Syrian Voices Worldwide': 'ربط الأصوات السورية عالمياً',
-      'Your Gateway to': 'بوابتك إلى',
-      'Syrian Knowledge': 'المعرفة السورية',
-      'Connect with Syrian experts, ask questions, share news, and engage in meaningful discussions about Syria\'s present and future': 'تواصل مع الخبراء السوريين، اطرح الأسئلة، شارك الأخبار، وشارك في نقاشات مهمة حول حاضر ومستقبل سوريا',
-      'Ask a Question': 'اطرح سؤالاً',
-      'Join as Expert': 'انضم كخبير',
       
       // Profile Updates
       profileUpdated: 'تم تحديث الملف الشخصي',


### PR DESCRIPTION
## Summary
- remove unused hero translation strings
- reuse `welcomeSubtitle` in `HeroSection`
- simplify `WelcomeHero` subtitle
- remove duplicate hero title strings and rely solely on translation keys

## Testing
- `bun run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6854b055609883269a136c7577c6e42e