### PR TITLE
Fix duplicate sign-up

### DIFF
--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -16,9 +16,9 @@ export const loginUser = async (email: string, password: string) => {
 };
 
 export const registerUser = async (
-  email: string, 
-  password: string, 
-  name: string, 
+  email: string,
+  password: string,
+  name: string,
   location: string,
   phoneNumber?: string,
   phoneCountryCode?: string,
@@ -26,6 +26,28 @@ export const registerUser = async (
   expertiseSpecialization?: string
 ) => {
   console.log('Attempting registration for:', email);
+
+  // Check if a verified profile already exists with this email
+  const {
+    data: existingProfile,
+    error: existingError,
+  } = await supabase
+    .from('profiles')
+    .select('verified')
+    .eq('email', email)
+    .maybeSingle();
+
+  if (existingError) {
+    console.error('Error checking existing profile:', existingError);
+    throw existingError;
+  }
+
+  if (existingProfile && existingProfile.verified) {
+    const error = new Error('User already registered');
+    console.error('Registration error:', error);
+    throw error;
+  }
+
   const { error } = await supabase.auth.signUp({
     email,
     password,


### PR DESCRIPTION
## Summary
- prevent duplicate registration by querying `profiles` for existing verified users

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861d764f6e08326a146f967b6bb1b5e